### PR TITLE
fix(uca): install live npm Codex latest, not a min-release-age-gated older tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ A tool for managing updates and version telemetry across five AI coding agent ha
 - Add `uninstall-uca.sh` (dedicated standalone uninstaller with Gum confirmation and service teardown)
 - Add `UNIVERSAL_CODING_AGENT_HARNESS_UPDATER.md` (comprehensive documentation guide)
 
+**Fixes** (2026-09-06):
+- npm-owned Codex updates now pass `--prefer-online --min-release-age=0` so
+  npm 11 does not skip a just-published `@latest` (or serve a stale packument)
+  and install an older version. A 7-day `min-release-age` in `~/.npmrc`
+  previously downgraded Codex 0.153.2 to 0.151.0.
+
 **Fixes** (2026-09-02):
 - `install-uca.sh` / `uninstall-uca.sh` aborted in any interactive terminal that had gum installed
   (`gum: error: unknown flag ->`, then `exec: "install_uca_script": executable file not found`).

--- a/UNIVERSAL_CODING_AGENT_HARNESS_UPDATER.md
+++ b/UNIVERSAL_CODING_AGENT_HARNESS_UPDATER.md
@@ -29,7 +29,7 @@ cd misc_coding_agent_tips_and_scripts
 | Harness | Target Binary | Update Command |
 |:---|:---|:---|
 | **Claude Code** | `~/.local/bin/claude` | `claude update` |
-| **OpenAI Codex** | active `codex` on PATH | Ownership-aware: `bun install -g` if the resolved binary lives under `~/.bun/bin`, `npm install -g` if under the npm global prefix, `codex update` for the standalone installer (`~/.codex/packages/standalone/`) or unknown installs |
+| **OpenAI Codex** | active `codex` on PATH | Ownership-aware: `bun install -g` if the resolved binary lives under `~/.bun/bin`, `npm install -g @openai/codex@latest --prefer-online --min-release-age=0` if under the npm global prefix, `codex update` for the standalone installer (`~/.codex/packages/standalone/`) or unknown installs |
 | **Google Antigravity** | `~/.local/bin/agy` | `agy update` |
 | **xAI Grok** | `~/.grok/bin/grok` | `grok update` |
 | **OMP** | `~/.bun/bin/omp` | `omp update` |

--- a/uca
+++ b/uca
@@ -346,7 +346,9 @@ update_codex() {
     bun)
       bun install -g @openai/codex@latest 2>&1 || ret=$? ;;
     npm)
-      npm install -g @openai/codex@latest 2>&1 || ret=$? ;;
+      # npm 11 honors min-release-age (often 7d via npmrc) and a stale
+      # packument cache, which can install an older dist-tag than @latest.
+      npm install -g @openai/codex@latest --prefer-online --min-release-age=0 2>&1 || ret=$? ;;
     standalone|*)
       # Standalone installer (or unknown ownership): use codex's own
       # updater rather than guessing a package manager.


### PR DESCRIPTION
## Before
UCA's npm Codex path ran `npm install -g @openai/codex@latest`. npm 11 honors `min-release-age` (7 days in some npmrc files) and a stale packument cache, so a just-published `@latest` is skipped and an older version is installed. That downgraded a live 0.153.2 install to 0.151.0.

## After
The npm path is `npm install -g @openai/codex@latest --prefer-online --min-release-age=0`. Bun and standalone Codex paths are unchanged.

## Test plan
- [x] `bash -n uca`
- [x] On an npm-owned Codex install with `min-release-age=7` in `~/.npmrc`, `uca codex` moved 0.151.0 to registry latest 0.153.4
